### PR TITLE
Use official memcache store adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Alternatively, you can pass these options to config.cache_store (also
 in production.rb):
 
 ```.ruby
-config.cache_store = :dalli_store, ENV["MEMCACHIER_SERVERS"],
+config.cache_store = :mem_cache_store, ENV["MEMCACHIER_SERVERS"],
                     {:username => ENV["MEMCACHIER_USERNAME"],
                      :password => ENV["MEMCACHIER_PASSWORD"]}
 ```
@@ -60,7 +60,7 @@ config.cache_store = :dalli_store, ENV["MEMCACHIER_SERVERS"],
 Ensure that the following configuration option is set in production.rb:
 
 ```.ruby
-config.cache_store = :dalli_store
+config.cache_store = :mem_cache_store
 ```
 
 ## Using MemCachier

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :dalli_store
+  config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Rails ships with it's own cache adapter on top of dalli. This isn't a big deal in Rails 5.1 but in Rails 5.2 the `:dalli_store` is not compatible with all caching options and can fail to invalidate silently.